### PR TITLE
API Change - Returns a response object with Data and Headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ req.Header.Set("Cache-Control", "no-cache")
 ctx := context.Background()
 
 // run it and capture the response
-var respData ResponseStruct
-if err := client.Run(ctx, req, &respData); err != nil {
+if respData, err := client.Run(ctx, req); err != nil {
     log.Fatal(err)
 }
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module graphql
+
+go 1.22.3
+
+require (
+	github.com/matryer/is v1.4.1
+	github.com/pkg/errors v0.9.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/matryer/is v1.4.1 h1:55ehd8zaGABKLXQUe2awZ99BD/PTc2ls+KV/dXphgEQ=
+github.com/matryer/is v1.4.1/go.mod h1:8I/i5uYgLzgsgEloJE1U6xx5HkBQpAZvepWuujKwMRU=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/graphql_json_test.go
+++ b/graphql_json_test.go
@@ -34,10 +34,11 @@ func TestDoJSON(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 	defer cancel()
-	var responseData map[string]interface{}
-	err := client.Run(ctx, &Request{q: "query {}"}, &responseData)
+	resp, err := client.Run(ctx, &Request{q: "query {}"})
 	is.NoErr(err)
 	is.Equal(calls, 1) // calls
+	responseData, ok := resp.Data.(map[string]interface{})
+	is.True(ok)
 	is.Equal(responseData["something"], "yes")
 }
 
@@ -60,8 +61,7 @@ func TestDoJSONServerError(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 	defer cancel()
-	var responseData map[string]interface{}
-	err := client.Run(ctx, &Request{q: "query {}"}, &responseData)
+	_, err := client.Run(ctx, &Request{q: "query {}"})
 	is.Equal(calls, 1) // calls
 	is.Equal(err.Error(), "graphql: server returned a non-200 status code: 500")
 }
@@ -89,8 +89,7 @@ func TestDoJSONBadRequestErr(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 	defer cancel()
-	var responseData map[string]interface{}
-	err := client.Run(ctx, &Request{q: "query {}"}, &responseData)
+	_, err := client.Run(ctx, &Request{q: "query {}"})
 	is.Equal(calls, 1) // calls
 	is.Equal(err.Error(), "graphql: miscellaneous message as to why the the request was bad")
 }
@@ -120,14 +119,13 @@ func TestQueryJSON(t *testing.T) {
 	is.True(req != nil)
 	is.Equal(req.vars["username"], "matryer")
 
-	var resp struct {
-		Value string
-	}
-	err := client.Run(ctx, req, &resp)
+	resp, err := client.Run(ctx, req)
 	is.NoErr(err)
 	is.Equal(calls, 1)
 
-	is.Equal(resp.Value, "some data")
+	responseData, ok := resp.Data.(map[string]interface{})
+	is.True(ok)
+	is.Equal(responseData["value"], "some data")
 }
 
 func TestHeader(t *testing.T) {
@@ -150,12 +148,11 @@ func TestHeader(t *testing.T) {
 	req := NewRequest("query {}")
 	req.Header.Set("X-Custom-Header", "123")
 
-	var resp struct {
-		Value string
-	}
-	err := client.Run(ctx, req, &resp)
+	resp, err := client.Run(ctx, req)
 	is.NoErr(err)
 	is.Equal(calls, 1)
 
-	is.Equal(resp.Value, "some data")
+	responseData, ok := resp.Data.(map[string]interface{})
+	is.True(ok)
+	is.Equal(responseData["value"], "some data")
 }


### PR DESCRIPTION
Fixes https://github.com/machinebox/graphql/issues/49

# Why?

Graphql sometimes needs to return headers, like `Set-Cookie`. 

# What

Rather than passing in a response object and having it filled out, `.Run` now returns a response object with a `Data` and `Headers` field.